### PR TITLE
Flask single section

### DIFF
--- a/flask/rotations/templates/base.html
+++ b/flask/rotations/templates/base.html
@@ -2,15 +2,6 @@
 <title>SEVERAL ROTATIONS</title>
 <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono" rel="stylesheet">
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-139161782-1"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-139161782-1');
-</script>
 <section class="content">
   <header>
     {% block header %}{% endblock %}

--- a/flask/rotations/templates/poem/index.html
+++ b/flask/rotations/templates/poem/index.html
@@ -17,6 +17,9 @@
     <div id="poem" class="body">
       <p>{{ poem }}</p>
     </div>
+    <p></p>
+    <p>--</p>
+    <p style="font-size: 17px"><a class="action" id="paginate" href="{{ url_for('read', id=previous) }}">Previous</a></p>
     <!-- Adds the back to top link -->
     <h1><a href="#top" id="back-to-top" class="back-to-top" style="display: inline;">&uarr;</a></h1>
   </article>

--- a/flask/rotations/templates/poem/read.html
+++ b/flask/rotations/templates/poem/read.html
@@ -17,6 +17,9 @@
     <div id="poem" class="body">
       <p>{{ poem }}</p>
     </div>
+    <p></p>
+    <p>--</p>
+    <p style="font-size: 17px"><a class="action" id="paginate" href="{{ url_for('read', id=previous) }}">Previous</a>{% if next %} / <a class="action" id="paginate" href="{{ url_for('read', id=next) }}">Next</a>{% endif %}</p>
     <!-- Adds the back to top link -->
     <h1><a href="#top" id="back-to-top" class="back-to-top" style="display: inline;">&uarr;</a></h1>
   </article>


### PR DESCRIPTION
Update poem generation and add previous/next options:
- Newly generated poems are now limited to 1 section of 10 lines.
- Each poem is followed by previous and next links so users can
  page backward and forward in time, with the exception of the
  latest poem, which only shows a previous option.

Also remove the GA script.